### PR TITLE
Use monospace font family for code and pre in messages

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -2814,6 +2814,11 @@ body .post-stream * {
   text-transform: none !important;
 }
 
+#main-outlet code,
+#main-outlet pre {
+  font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace;
+}
+
 .footer-message * {
   font-weight: normal;
   font-family: "Noto Sans" !important;


### PR DESCRIPTION
See https://forums.concretecms.org/t/code-not-well-formatted-in-forum-messages/784